### PR TITLE
Change progress values to be between 0 and 1

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,18 +13,18 @@ Beautiful and responsive progress bars with animated SVG paths.
 
 
 * [Circle(container, options)](#circlecontainer-options)
-    * [animate(percent, options)](#circleanimatepercent-options)
-    * [set(percent)](#circlesetpercent)
+    * [animate(progress, options)](#circleanimateprogress-options)
+    * [set(progress)](#circlesetprogress)
 
 
 * [Square(container, options)](#squarecontainer-options)
-    * [animate(percent, options)](#squareanimatepercent-options)
-    * [set(percent)](#squaresetpercent)
+    * [animate(progress, options)](#squareanimateprogress-options)
+    * [set(progress)](#squaresetprogress)
 
 
 * [Path(path, options)](#pathpath-options)
-    * [animate(percent, options)](#pathanimatepercent-options)
-    * [set(percent)](#pathsetpercent)
+    * [animate(progress, options)](#pathanimateprogress-options)
+    * [set(progress)](#pathsetprogress)
 
 All built-in shapes are drawn on 100x100 square SVG canvas.
 All shapes fill their canvases.
@@ -88,13 +88,13 @@ var progressBar = new ProgressBar.Circle('#container', {
 });
 ```
 
-## Circle.animate(percent, options)
+## Circle.animate(progress, options)
 
 Animates drawing of circle.
 
 **Parameters**
 
-* `percent` Percent from 0 to 100.
+* `progress` Progress from 0 to 1, where 1 means 100% complete.
 * `options` Animation options. These options override the defaults given in initialization.
 
     ```javascript
@@ -112,14 +112,14 @@ Animates drawing of circle.
 **Example**
 
 ```javascript
-progressBar.animate(30, {
+progressBar.animate(0.3, {
     duration: 800
 });
 ```
 
-## Circle.set(percent)
+## Circle.set(progress)
 
-Set progress to a percent instantly without animation.
+Set progress to the given value between 0 and 1 instantly and without animation.
 
 <br>
 <br>
@@ -183,13 +183,13 @@ var progressBar = new ProgressBar.Square('#container', {
 });
 ```
 
-## Square.animate(percent, options)
+## Square.animate(progress, options)
 
 Animates drawing of square.
 
 **Parameters**
 
-* `percent` Percent from 0 to 100.
+* `progress` Progress from 0 to 1, where 1 means 100% complete.
 * `options` Animation options. These options override the defaults given in initialization.
 
     ```javascript
@@ -207,14 +207,14 @@ Animates drawing of square.
 **Example**
 
 ```javascript
-progressBar.animate(30, {
+progressBar.animate(0.3, {
     duration: 800
 });
 ```
 
-## Square.set(percent)
+## Square.set(progress)
 
-Set progress to a percent instantly without animation.
+Set progress to the given value between 0 and 1 instantly and without animation.
 
 <br>
 <br>
@@ -261,13 +261,13 @@ var path = new ProgressBar.Path(svgPath, {
 });
 ```
 
-## Path.animate(percent, options)
+## Path.animate(progress, options)
 
 Animates drawing of path.
 
 **Parameters**
 
-* `percent` Percent from 0 to 100.
+* `progress` Progress from 0 to 1, where 1 means 100% complete.
 * `options` Animation options. These options override the defaults given in initialization.
 
     ```javascript
@@ -285,11 +285,11 @@ Animates drawing of path.
 **Example**
 
 ```javascript
-path.animate(30, {
+path.animate(0.3, {
     duration: 800
 });
 ```
 
-## Path.set(percent)
+## Path.set(progress)
 
-Set progress to a percent instantly without animation.
+Set progress to the given value between 0 and 1 instantly and without animation.

--- a/progressbar.js
+++ b/progressbar.js
@@ -37,7 +37,7 @@
             var trailPath = this._createPath(trailOpts);
             svg.appendChild(trailPath);
         }
-        
+
         var path = this._createPath(opts);
         svg.appendChild(path);
 
@@ -118,14 +118,14 @@
         this._path.style.strokeDashoffset = length;
     };
 
-    Path.prototype.set = function set(percent) {
+    Path.prototype.set = function set(progress) {
         this._path.style.transition = this._path.style.WebkitTransition = 'none';
-        this._path.style.strokeDashoffset = length - (percent / 100) * length;
+        this._path.style.strokeDashoffset = length - progress * length;
     };
 
     // Method introduced here:
     // http://jakearchibald.com/2013/animated-line-drawing-svg/
-    Path.prototype.animate = function animate(percent, opts) {
+    Path.prototype.animate = function animate(progress, opts) {
         // Copy default opts to new object so defaults are not modified
         var defaultOpts = extend({}, this._opts);
         opts = extend(defaultOpts, opts);
@@ -142,7 +142,7 @@
         // Animate
         this._path.style.transition = this._path.style.WebkitTransition =
           'stroke-dashoffset ' + opts.duration + 'ms ' + opts.easing;
-        this._path.style.strokeDashoffset = length - (percent / 100) * length;
+        this._path.style.strokeDashoffset = length - progress * length;
     };
 
     // Utility functions


### PR DESCRIPTION
Whereas '100' is sort of an arbitrary value without context ("it's a percentage"), having progress be from 0 to 1 is more natural, and makes it simpler to wire animation up to existing APIs. For example, to animate XHR progress with the percentage API, one would write:

``` js
var x = new XMLHttpRequest();
x.addEventListener('progress', function (e) {
  if (e.lengthComputable) {
    circle.animate((e.loaded / e.total) * 100);
  }
});
x.open('GET', url);
x.send();
```

After this change, we could drop the extra multiplication:

``` js
var x = new XMLHttpRequest();
x.addEventListener('progress', function (e) {
  if (e.lengthComputable) {
    circle.animate(e.loaded / e.total);
  }
});
x.open('GET', url);
x.send();
```
