### PR TITLE
Add trailWidth and centerTail options

### DIFF
--- a/src/progressbar.js
+++ b/src/progressbar.js
@@ -163,7 +163,7 @@ Circle.prototype._pathString = function _pathString(opts) {
     // Use two arcs to form a circle
     // See this answer http://stackoverflow.com/a/10477334/1446092
     var pathString = "M 50,50 m 0,-{r} a {r},{r} 0 1 1 0,{r*2} a {r},{r} 0 1 1 0,-{r*2}";
-    var r = 50 - opts.strokeWidth / 2;
+    var r = 50 - opts.strokeWidth / 2 - (opts.radiusAdjust || 0);
     pathString = pathString.replace(/\{r\}/g, r);
     pathString = pathString.replace(/\{r\*2\}/g, r * 2);
     return pathString;


### PR DESCRIPTION
Allow users to specify trail width and center tail on the path. 
![screen shot 2014-11-19 at 1 14 35 pm](https://cloud.githubusercontent.com/assets/1610182/5114523/377d01a6-6fee-11e4-86c2-2937837fa258.png)

Sample usage:

```
        var progressBar = new ProgressBar.Circle(document.getElementById("container"), {
            strokeWidth: 10,
            color: "#fb7d08",
            trailColor: "#9797a5",
            trailWidth: 1,
            centerTrail: true
        });

        progressBar.set(0.3);


        var progressBar2 = new ProgressBar.Circle(document.getElementById("container"), {
            strokeWidth: 10,
            trailWidth: 1,
            trailColor: "#9797a5",
            centerTrail: true,
            color: "#6cb519"
        });
```
