### PR TITLE
Throw error if progress bars are initialized without new keyword

### DIFF
--- a/src/progressbar.js
+++ b/src/progressbar.js
@@ -18,7 +18,11 @@ var Progress = function Progress(container, opts) {
     }
 
     // Prevent calling constructor without parameters so inheritance
-    // works correctly
+    // works correctly. To understand, this is how Progress is inherited:
+    //
+    //   Line.prototype = new Progress();
+    //
+    // We just want to set the prototype for Line.
     if (arguments.length === 0) return;
 
     var svgView = this._createSvgView(opts);
@@ -131,7 +135,7 @@ Progress.prototype._pathString = function _pathString(opts) {
 
 // Progress bar shapes
 
-var Line = function(container, options) {
+var Line = function Line(container, options) {
     Progress.apply(this, arguments);
 };
 
@@ -150,7 +154,7 @@ Line.prototype._pathString = function _pathString(opts) {
     return pathString;
 };
 
-var Circle = function(container, options) {
+var Circle = function Circle(container, options) {
     Progress.apply(this, arguments);
 };
 
@@ -167,7 +171,7 @@ Circle.prototype._pathString = function _pathString(opts) {
     return pathString;
 };
 
-var Square = function(container, options) {
+var Square = function Square(container, options) {
     Progress.apply(this, arguments);
 };
 
@@ -185,7 +189,7 @@ Square.prototype._pathString = function _pathString(opts) {
 
 // Lower level API to animate any kind of svg path
 
-var Path = function(path, opts) {
+var Path = function Path(path, opts) {
     opts = extend({
         duration: 800,
         easing: "linear",


### PR DESCRIPTION
Change bad error message `undefined is not a function` to more descriptive: `not called with new keyword` error.
