### PR TITLE
Attempting to fix travis builds

### DIFF
--- a/test/path-behaviour.js
+++ b/test/path-behaviour.js
@@ -27,11 +27,10 @@ var barOpts = {
 };
 
 var createPath = function () {
-    var container = document.getElementById('container'),
+    var container = document.querySelector('#container'),
         svg = document.createElementNS('http://www.w3.org/2000/svg', 'svg'),
         path = document.createElementNS('http://www.w3.org/2000/svg', 'path');
 
-    container.setAttribute('style', 'width: 200px;');
 
     svg.setAttribute('version', '1.1');
     svg.setAttribute('id', 'progress-bar');
@@ -57,12 +56,12 @@ var createPath = function () {
 
     container.appendChild(svg);
 
-    return document.getElementById('progress-path');
+    return path;
 };
 
 var destroyPath = function () {
-    var container = document.getElementById('container'),
-        svg = document.getElementById('progress-bar');
+    var container = document.querySelector('#container'),
+        svg = document.querySelector('#progress-bar');
     container.removeAttribute('style');
 
     container.removeChild(svg);

--- a/test/path-behaviour.js
+++ b/test/path-behaviour.js
@@ -8,10 +8,6 @@ var sinon = require('sinon');
 
 var PRECISION = 2;
 
-
-
-var svgStr = '<svg version="1.1" id="progress-bar" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px" viewBox="0 0 197 165.39555" enable-background="0 0 197 165.39555" xml:space="preserve"><path id="progress-path" fill="none" stroke="none" stroke-width="15" stroke-miterlimit="10" d="m 31.7,160.3 c -15,-16.2 -24.2,-38 -24.2,-61.8 0,-50.3 40.7,-91 91,-91 50.3,0 91,40.7 91,91 0,23.9 -9.2,45.6 -24.2,61.8"/></svg>';
-
 var ANIM_PROP = {
     'styleName': 'stroke-offset',
     'scriptName': 'strokeOffset'
@@ -27,7 +23,7 @@ var barOpts = {
 };
 
 var createPath = function () {
-    var container = document.querySelector('#container'),
+    var container = document.querySelector('body'),
         svg = document.createElementNS('http://www.w3.org/2000/svg', 'svg'),
         path = document.createElementNS('http://www.w3.org/2000/svg', 'path');
 
@@ -56,25 +52,10 @@ var createPath = function () {
 
     container.appendChild(svg);
 
-    return path;
-};
-
-var destroyPath = function () {
-    var container = document.querySelector('#container'),
-        svg = document.querySelector('#progress-bar');
-    container.removeAttribute('style');
-
-    container.removeChild(svg);
-    container.innerHTML = '';
-};
-
-var afterEachCase = function() {
-    try {
-        destroyPath();
-    } catch (e) {
-        // Some test cases destroy the bar themselves and calling again
-        // throws an error
-    }
+    return {
+        "path": path,
+        "svg": svg
+    };
 };
 
 var pathTests = function pathTests () {
@@ -164,7 +145,5 @@ var pathTests = function pathTests () {
 module.exports = {
     options: barOpts,
     runTests: pathTests,
-    afterEachCase: afterEachCase,
-    createPath: createPath,
-    destroyPath: destroyPath
+    createPath: createPath
 };

--- a/test/test-all.js
+++ b/test/test-all.js
@@ -39,7 +39,7 @@ describe('Line', function() {
         this.bar = new ProgressBar.Line('body', barOpts);
         this.attachment = this.bar._opts.attachment;
         this.step = sinon.spy(this.bar._opts, 'step');
-        
+
     });
 
     afterEach(afterEachCase);
@@ -53,7 +53,7 @@ describe('Circle', function() {
         this.bar = new ProgressBar.Circle('body', barOpts);
         this.attachment = this.bar._opts.attachment;
         this.step = sinon.spy(this.bar._opts, 'step');
-        
+
     });
 
     afterEach(afterEachCase);
@@ -67,7 +67,7 @@ describe('Square', function() {
         barOpts.step = function (state, bar, attachment) {};
         this.bar = new ProgressBar.Square('body', barOpts);
         this.attachment = this.bar._opts.attachment;
-        this.step = sinon.spy(this.bar._opts, 'step'); 
+        this.step = sinon.spy(this.bar._opts, 'step');
     });
 
     afterEach(afterEachCase);
@@ -77,7 +77,9 @@ describe('Square', function() {
 describe('Path', function () {
 
     beforeEach(function () {
-        this.path = pathTests.createPath();
+        var svgView = pathTests.createPath();
+        this.svg = svgView.svg;
+        this.path = svgView.path;
         this.path.setAttribute('strokeOffset', this.path.getTotalLength());
         pathTests.options.attachment = this.path;
 
@@ -86,7 +88,14 @@ describe('Path', function () {
         this.step = sinon.spy(this.bar._opts, 'step');
     });
 
-    afterEach(pathTests.afterEachCase);
+    afterEach(function () {
+        var container = this.svg.parentNode;
+        container.removeChild(this.svg);
+        this.svg = null;
+        pathTests.options.attachment = null;
+        this.path = null;
+        this.bar = null;
+    });
 
     pathTests.runTests();
 });


### PR DESCRIPTION
@kimmobrunfeldt So I switched from `document.getElementById` to `document.querySelector` since that is what you use internally within the Shape bars and all those tests work fine. I'm not sure why that would make a difference (perhaps you have some insight?). 

One thing that is noticeable is that when I ran tests before it would report bask that all tests passed but whatever mechanism I was using would often hang and i would have to CTRL+C out of it. That does not happen anymore so I am thinking perhaps that is related to whats happening in the Travis environment and this will fix it up. References #49 