### PR TITLE
Upgrade shifty to v1.5.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Beautiful and responsive progress bars with animated SVG paths",
   "main": "src/main.js",
   "dependencies": {
-    "shifty": "1.2.2"
+    "shifty": "1.5.0"
   },
   "devDependencies": {
     "bluebird": "^2.3.6",


### PR DESCRIPTION
Shifty has been fixed lots of issues from v1.2.2. The major issue for me is this one jeremyckahn/shifty#53, it caused webpack getting errors.

Please upgrade shifty to the latest version. Thanks :+1: 