### PR TITLE
Make an outline for Shape

### DIFF
--- a/docs/api/shape.md
+++ b/docs/api/shape.md
@@ -58,6 +58,15 @@ with CSS.
         // Default: same as strokeWidth
         trailWidth: 0.8,
 
+        // Color for outline stroke
+        // over the actual progress path.
+        // Default: '#eee'
+        outlineColor: '#f4f4f4',
+
+        // Width of the outline stroke. 
+        // Default: 0 , so doesn't show, unless this value is more than 0
+        outlineWidth: 0.8,
+
         // Inline CSS styles for the created SVG element
         // Set null to disable all default styles.
         // You can disable individual defaults by setting them to `null`

--- a/src/circle.js
+++ b/src/circle.js
@@ -45,13 +45,13 @@ Circle.prototype._trailString = function _trailString(opts) {
     return this._pathString(opts);
 };
 
-Circle.prototype._outlineString = function _outlineString(opts){
+Circle.prototype._outlineString = function _outlineString(opts) {
     /*
       The outline is drawn inside the circle so that the path doesn't clip
     */
 
     // prevent the outline extending outside the circle
-    if(opts.outlineWidth && opts.outlineWidth > opts.strokeWidth){
+    if(opts.outlineWidth && opts.outlineWidth > opts.strokeWidth) {
       opts.outlineWidth = opts.strokeWidth / 2;
     }
 

--- a/src/circle.js
+++ b/src/circle.js
@@ -11,6 +11,14 @@ var Circle = function Circle(container, options) {
         ' a {radius},{radius} 0 1 1 0,{2radius}' +
         ' a {radius},{radius} 0 1 1 0,-{2radius}';
 
+    this._pathOutlineTemplate =
+        ' M 50,50 m 0,-{inner_radius}' +
+        ' a {inner_radius},{inner_radius} 0 1 1 0,{2inner_radius}' +
+        ' a {inner_radius},{inner_radius} 0 1 1 0,-{2inner_radius}'+
+        'M 50,50 m 0,-{outer_radius}' +
+        ' a {outer_radius},{outer_radius} 0 1 1 0,{2outer_radius}' +
+        ' a {outer_radius},{outer_radius} 0 1 1 0,-{2outer_radius}';
+
     this.containerAspectRatio = 1;
 
     Shape.apply(this, arguments);
@@ -35,6 +43,27 @@ Circle.prototype._pathString = function _pathString(opts) {
 
 Circle.prototype._trailString = function _trailString(opts) {
     return this._pathString(opts);
+};
+
+Circle.prototype._outlineString = function _outlineString(opts){
+    /*
+      The outline is drawn inside the circle so that the path doesn't clip
+    */
+
+    // prevent the outline extending outside the circle
+    if(opts.outlineWidth && opts.outlineWidth > opts.strokeWidth){
+      opts.outlineWidth = opts.strokeWidth / 2;
+    }
+
+    var inner_r = 50 - opts.strokeWidth + opts.outlineWidth/2;
+    var outer_r = 50 - opts.outlineWidth/2;
+
+    return utils.render(this._pathOutlineTemplate, {
+      inner_radius: inner_r,
+      '2inner_radius': inner_r * 2,
+      outer_radius: outer_r,
+      '2outer_radius': outer_r * 2
+    });
 };
 
 module.exports = Circle;

--- a/src/line.js
+++ b/src/line.js
@@ -5,6 +5,12 @@ var utils = require('./utils');
 
 var Line = function Line(container, options) {
     this._pathTemplate = 'M 0,{center} L 100,{center}';
+    this._pathOutlineTemplate =
+        ' M 0,0' +
+        ' m {outlineWidth},{outlineWidth}  H100' +
+        ' m -{outlineWidth},0  v {height}' +
+        ' m 0,-{outlineWidth}  H0' +
+        ' m {outlineWidth},0 v -{height}';
     Shape.apply(this, arguments);
 };
 
@@ -13,7 +19,7 @@ Line.prototype.constructor = Line;
 
 Line.prototype._initializeSvg = function _initializeSvg(svg, opts) {
     svg.setAttribute('viewBox', '0 0 100 ' + opts.strokeWidth);
-    svg.setAttribute('preserveAspectRatio', 'none');
+    //svg.setAttribute('preserveAspectRatio', 'none');
 };
 
 Line.prototype._pathString = function _pathString(opts) {
@@ -24,6 +30,22 @@ Line.prototype._pathString = function _pathString(opts) {
 
 Line.prototype._trailString = function _trailString(opts) {
     return this._pathString(opts);
+};
+
+Line.prototype._outlineString = function _outlineString(opts){
+    /*
+      The outline is drawn inside the circle so that the path doesn't clip
+    */
+
+    // prevent the outline extending outside the circle
+    if(opts.outlineWidth && opts.outlineWidth > opts.strokeWidth){
+      opts.outlineWidth = opts.strokeWidth / 2;
+    }
+
+    return utils.render(this._pathOutlineTemplate, {
+        outlineWidth: opts.outlineWidth / 2,
+        height: opts.strokeWidth - opts.outlineWidth / 2
+    });
 };
 
 module.exports = Line;

--- a/src/line.js
+++ b/src/line.js
@@ -19,7 +19,6 @@ Line.prototype.constructor = Line;
 
 Line.prototype._initializeSvg = function _initializeSvg(svg, opts) {
     svg.setAttribute('viewBox', '0 0 100 ' + opts.strokeWidth);
-    //svg.setAttribute('preserveAspectRatio', 'none');
 };
 
 Line.prototype._pathString = function _pathString(opts) {

--- a/src/semicircle.js
+++ b/src/semicircle.js
@@ -11,6 +11,14 @@ var SemiCircle = function SemiCircle(container, options) {
         'M 50,50 m -{radius},0' +
         ' a {radius},{radius} 0 1 1 {2radius},0';
 
+    this._pathOutlineTemplate =
+        ' M 50,50 m -{inner_radius},0' +
+        ' a {inner_radius},{inner_radius} 0 1 1 {2inner_radius},0' +
+        ' l {width} 0'+
+        'M 50,50 m {outer_radius},0' +
+        ' a {outer_radius},{outer_radius} 0 1 0 -{2outer_radius},0' +
+        ' l {width} 0';
+
     this.containerAspectRatio = 2;
 
     Shape.apply(this, arguments);
@@ -44,5 +52,26 @@ SemiCircle.prototype._initializeTextContainer = function _initializeTextContaine
 // Share functionality with Circle, just have different path
 SemiCircle.prototype._pathString = Circle.prototype._pathString;
 SemiCircle.prototype._trailString = Circle.prototype._trailString;
+SemiCircle.prototype._outlineString = function _outlineString(opts){
+    /*
+      The outline is drawn inside the circle so that the path doesn't clip
+    */
+
+    // prevent the outline extending outside the circle
+    if(opts.outlineWidth && opts.outlineWidth > opts.strokeWidth){
+      opts.outlineWidth = opts.strokeWidth / 2;
+    }
+
+    var inner_r = 50 - opts.strokeWidth + opts.outlineWidth/2;
+    var outer_r = 50 - opts.outlineWidth/2;
+
+    return utils.render(this._pathOutlineTemplate, {
+      inner_radius: inner_r,
+      '2inner_radius': inner_r * 2,
+      outer_radius: outer_r,
+      '2outer_radius': outer_r * 2,
+      width: opts.strokeWidth - opts.outlineWidth
+    });
+};
 
 module.exports = SemiCircle;

--- a/src/shape.js
+++ b/src/shape.js
@@ -28,6 +28,8 @@ var Shape = function Shape(container, opts) {
         strokeWidth: 1.0,
         trailColor: null,
         trailWidth: null,
+        outlineColor: null,
+        outlineWidth: 0,
         fill: null,
         text: {
             style: {
@@ -197,6 +199,13 @@ Shape.prototype._createSvgView = function _createSvgView(opts) {
     var path = this._createPath(opts);
     svg.appendChild(path);
 
+    var outlinePath = null;
+    if (opts.outlineColor || opts.outlineWidth > 0){
+        outlinePath = this._createOutline(opts);
+        svg.appendChild(outlinePath);
+
+    }
+
     return {
         svg: svg,
         path: path,
@@ -233,6 +242,31 @@ Shape.prototype._createTrail = function _createTrail(opts) {
 
     // When trail path is set, fill must be set for it instead of the
     // actual path to prevent trail stroke from clipping
+    newOpts.fill = null;
+
+    return this._createPathElement(pathString, newOpts);
+};
+
+Shape.prototype._createOutline = function _createOutline(opts) {
+    // Create path string with original passed options
+    var pathString = this._outlineString(opts);
+
+    // Prevent modifying original
+    var newOpts = utils.extend({}, opts);
+
+    // Defaults for parameters which modify outline path
+    if (!newOpts.outlineColor) {
+        newOpts.outlineColor = '#eee';
+    }
+    if (!newOpts.outlineWidth) {
+        newOpts.outlineWidth = 0;
+    }
+
+    newOpts.color = newOpts.outlineColor;
+    newOpts.strokeWidth = newOpts.outlineWidth;
+
+    // When outline path is set, fill must be set for it instead of the
+    // actual path to prevent outline stroke from clipping
     newOpts.fill = null;
 
     return this._createPathElement(pathString, newOpts);
@@ -285,6 +319,10 @@ Shape.prototype._pathString = function _pathString(opts) {
 };
 
 Shape.prototype._trailString = function _trailString(opts) {
+    throw new Error('Override this function for each progress bar');
+};
+
+Shape.prototype._outlineString = function _outlineString(opts) {
     throw new Error('Override this function for each progress bar');
 };
 


### PR DESCRIPTION
This should create outlines to the Shapes (Circle, SemiCircle, and Line). My concern is that for outline to behave properly in Line, "preserveAspectRatio" (line#22) that is set to none should be commented out, which might break existing code. 

I can change it back if you think it should be that way, but it might need more documentation to show how to achieve the outlines.

References #155 , though this is in addition to trail. 