### PR TITLE
Upgrade Shifty to 2.1.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,11 +18,11 @@
     "grunt-cli": "^0.1.13",
     "grunt-contrib-jshint": "^0.10.0",
     "grunt-contrib-uglify": "^0.6.0",
-    "grunt-karma": "^0.9.0",
+    "grunt-karma": "^2.0.0",
     "grunt-shell": "^1.1.1",
     "jscs": "^2.0.0",
-    "karma": "^0.12.24",
-    "karma-bro": "^0.8.0",
+    "karma": "^1.7.1",
+    "karma-browserify": "^5.1.1",
     "karma-mocha": "^0.1.9",
     "karma-sauce-launcher": "^0.2.10",
     "lodash": "^2.4.1",
@@ -34,7 +34,7 @@
     "sinon": "~1.14.1",
     "string": "^2.2.0",
     "testem": "^1.6.0",
-    "watchify": "^2.1.1"
+    "watchify": "^3.9.0"
   },
   "scripts": {
     "test": "./tools/test.sh",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Responsive and slick progress bars with animated SVG paths",
   "main": "src/main.js",
   "dependencies": {
-    "shifty": "^1.5.2"
+    "shifty": "^2.1.2"
   },
   "devDependencies": {
     "bluebird": "^2.3.6",

--- a/src/path.js
+++ b/src/path.js
@@ -1,7 +1,9 @@
 // Lower level API to animate any kind of svg path
 
-var Tweenable = require('shifty');
+var shifty = require('shifty');
 var utils = require('./utils');
+
+var Tweenable = shifty.Tweenable;
 
 var EASING_ALIASES = {
     easeIn: 'easeInCubic',
@@ -146,12 +148,12 @@ Path.prototype._resolveFromAndTo = function _resolveFromAndTo(progress, easing, 
 
 // Calculate `from` values from options passed at initialization
 Path.prototype._calculateFrom = function _calculateFrom(easing) {
-    return Tweenable.interpolate(this._opts.from, this._opts.to, this.value(), easing);
+    return shifty.interpolate(this._opts.from, this._opts.to, this.value(), easing);
 };
 
 // Calculate `to` values from options passed at initialization
 Path.prototype._calculateTo = function _calculateTo(progress, easing) {
-    return Tweenable.interpolate(this._opts.from, this._opts.to, progress, easing);
+    return shifty.interpolate(this._opts.from, this._opts.to, progress, easing);
 };
 
 Path.prototype._stopTween = function _stopTween() {

--- a/src/path.js
+++ b/src/path.js
@@ -112,11 +112,10 @@ Path.prototype.animate = function animate(progress, opts, cb) {
             self.path.style.strokeDashoffset = state.offset;
             var reference = opts.shape || self;
             opts.step(state, reference, opts.attachment);
-        },
-        finish: function(state) {
-            if (utils.isFunction(cb)) {
-                cb();
-            }
+        }
+    }).then(function(state) {
+        if (utils.isFunction(cb)) {
+            cb();
         }
     });
 };


### PR DESCRIPTION
Hi @kimmobrunfeldt!  This PR upgrades progressbar.js to the latest version of Shifty.  Among other things, Shifty offers [significantly improved performance over 1.x](https://codepen.io/jeremyckahn/pen/prMYXj).

I was able to the run the CLI tests locally and get them to pass, but I wasn't able to fully install all of the dependencies and I couldn't quite run the modified code in my browser.  I can spend a little more time with trying to get this working on my machine (there's probably some environment-specific weirdness going on), but please let me know if this works for you.  Thanks!