### PR TITLE
Remove duplicate key

### DIFF
--- a/.jscs.json
+++ b/.jscs.json
@@ -2,7 +2,6 @@
     "disallowImplicitTypeConversion": ["string"],
     "disallowMixedSpacesAndTabs": true,
     "disallowMultipleLineBreaks": true,
-    "disallowMultipleVarDecl": true,
     "disallowNewlineBeforeBlockStatements": true,
     "disallowMultipleLineStrings": true,
     "disallowMultipleVarDecl": null,


### PR DESCRIPTION
disallowMultipleVarDecl is entered twice, first true, then null. Removing the true since this is most likely to change nothing, but please consider what this property should be.