### PR TITLE
Add delay parameter

### DIFF
--- a/docs/api/path.md
+++ b/docs/api/path.md
@@ -60,6 +60,10 @@ var path = new ProgressBar.Path(heartObject.contentDocument.querySelector('#hear
         // Default: 800
         duration: 1200,
 
+        // Delay for animation in milliseconds
+        // Default: 0
+        delay: 100,
+
         // Easing for animation. See #easing section.
         // Default: 'linear'
         easing: 'easeIn',
@@ -107,6 +111,10 @@ path.animate(0.3, {
         // Duration for animation in milliseconds
         // Default: 800
         duration: 1200,
+
+        // Delay for animation in milliseconds
+        // Default: 0
+        delay: 100,
 
         // Easing for animation. See #easing section.
         // Default: 'linear'

--- a/docs/api/shape.md
+++ b/docs/api/shape.md
@@ -132,6 +132,10 @@ with CSS.
         // Default: 800
         duration: 1200,
 
+        // Delay for animation in milliseconds
+        // Default: 0
+        delay: 100,
+
         // Easing for animation. See #easing section.
         // Default: 'linear'
         easing: 'easeOut',
@@ -194,6 +198,10 @@ progressBar.animate(0.3, {
         // Duration for animation in milliseconds
         // Default: 800
         duration: 1200,
+
+        // Delay for animation in milliseconds
+        // Default: 0
+        delay: 100,
 
         // Easing for animation. See #easing section.
         // Default: 'linear'

--- a/src/path.js
+++ b/src/path.js
@@ -19,6 +19,7 @@ var Path = function Path(path, opts) {
 
     // Default parameters for animation
     opts = utils.extend({
+        delay: 0,
         duration: 800,
         easing: 'linear',
         from: {},
@@ -107,6 +108,7 @@ Path.prototype.animate = function animate(progress, opts, cb) {
         from: utils.extend({ offset: offset }, values.from),
         to: utils.extend({ offset: newOffset }, values.to),
         duration: opts.duration,
+        delay: opts.delay,
         easing: shiftyEasing,
         step: function(state) {
             self.path.style.strokeDashoffset = state.offset;


### PR DESCRIPTION
Hey!

This PR exposes [Shifty's](https://github.com/jeremyckahn/shifty) `delay` parameter to progressbar.js animation options, as described in #249.

It also updates the documentation to include the `delay` parameter in options.

Let me know if that's okay 😄 