### PR TITLE
Fix Issue #255

### DIFF
--- a/src/path.js
+++ b/src/path.js
@@ -119,7 +119,7 @@ Path.prototype.animate = function animate(progress, opts, cb) {
         if (utils.isFunction(cb)) {
             cb();
         }
-    });
+    }).catch(function(state) {});
 };
 
 Path.prototype._getComputedDashOffset = function _getComputedDashOffset() {


### PR DESCRIPTION
Catch "uncaught in promise"-error that is thrown when animate function is called while an animation is still running.